### PR TITLE
Add kingpin.v2 to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ sausage-clean:
 
 get-deps:
 	go get -v github.com/pivotal-golang/bytefmt
+	go get -v gopkg.in/alecthomas/kingpin.v2
 
 test: sausage-test
 


### PR DESCRIPTION
- an import for gopkg.in/alecthomas/kingpin.v2 was added to main.go in e996c96
- go get gopkg.in/alecthomas/kingpin.v2 in get-deps Makefile

Edit: Guess you'll need to wait for this to be merged upstream https://github.com/pivotal-golang/bytefmt/pull/6
